### PR TITLE
Keep Directory structure

### DIFF
--- a/remarks/remarks.py
+++ b/remarks/remarks.py
@@ -8,7 +8,7 @@ from .conversion.drawing import draw_svg, draw_pdf
 from .conversion.text import md_from_blocks, is_text_extractable
 from .conversion.ocrmypdf import is_tool, run_ocr
 
-from .utils import get_pdf_name, get_pdf_page_dims, list_pages_uuids, list_ann_rm_files
+from .utils import get_pdf_name, get_pdf_path, get_pdf_page_dims, list_pages_uuids, list_ann_rm_files
 
 
 def prepare_subdir(base_dir, fmt):
@@ -33,7 +33,9 @@ def run_remarks(input_dir, output_dir, targets=None, pdf_name=None, ann_type=Non
 
         page_magnitude = math.floor(math.log10(len(pages))) + 1
 
-        _dir = pathlib.Path(f"{output_dir}/{name}/")
+        pdf_path = get_pdf_path(path)
+
+        _dir = pathlib.Path(f"{output_dir}/{pdf_path}/{name}/")
         _dir.mkdir(parents=True, exist_ok=True)
 
         pdf_src = fitz.open(path)

--- a/remarks/utils.py
+++ b/remarks/utils.py
@@ -2,6 +2,7 @@ import json
 import pathlib
 
 import fitz  # PyMuPDF
+from os.path import dirname, abspath, join
 
 
 def get_pdf_name(path):
@@ -12,6 +13,30 @@ def get_pdf_name(path):
     # print(metadata)
     return metadata["visibleName"]
 
+def get_pdf_path(path):
+    metadata_file = path.with_name(f"{path.stem}.metadata")
+    if not metadata_file.exists():
+        return None
+    metadata = json.loads(open(metadata_file).read())
+    # Check the parent 
+    path_tmp = ""
+    file_path = path
+    parent_filename = metadata["parent"]
+    while parent_filename != "":
+        # First get the total path of the parent
+        parent_path = join(dirname(abspath(file_path)), metadata["parent"])
+        # Get the meta data of this parent
+        metadata_file = parent_path + ".metadata"
+        metadata = json.loads(open(metadata_file).read())
+        parent_title = metadata["visibleName"]
+        # These go in reverse order up to the top level
+        path_tmp = join(parent_title,path_tmp)
+        # Get the parent of this one
+        parent_filename = metadata["parent"]
+    # Strip off final slash
+    path_tmp = path_tmp.strip("/")
+    path_tmp = path_tmp.strip("\\")
+    return path_tmp
 
 def get_pdf_page_dims(path, page_number=0):
     with fitz.open(path) as doc:


### PR DESCRIPTION
refs #3
In the output directory, put the annotated pdf files in the same
directory structure as in remarkable. Recursively parses the parents
metadata until reaching the top level. Used OS independent path strings.