### PR TITLE
Keep Directory structure by folofjc

### DIFF
--- a/remarks/__init__.py
+++ b/remarks/__init__.py
@@ -1,4 +1,10 @@
 from . import conversion
 
 from .remarks import run_remarks
-from .utils import get_pdf_name, get_pdf_page_dims, list_pages_uuids, list_ann_rm_files
+from .utils import (
+    get_visible_name,
+    get_ui_path,
+    get_pdf_page_dims,
+    list_pages_uuids,
+    list_ann_rm_files,
+)

--- a/remarks/remarks.py
+++ b/remarks/remarks.py
@@ -8,7 +8,7 @@ from .conversion.drawing import draw_svg, draw_pdf
 from .conversion.text import md_from_blocks, is_text_extractable
 from .conversion.ocrmypdf import is_tool, run_ocr
 
-from .utils import get_pdf_name, get_pdf_page_dims, list_pages_uuids, list_ann_rm_files
+from .utils import get_pdf_name, get_pdf_path, get_pdf_page_dims, list_pages_uuids, list_ann_rm_files
 
 
 def prepare_subdir(base_dir, fmt):
@@ -33,7 +33,9 @@ def run_remarks(input_dir, output_dir, targets=None, pdf_name=None, ann_type=Non
 
         page_magnitude = math.floor(math.log10(len(pages))) + 1
 
-        _dir = pathlib.Path(f"{output_dir}/{name}/")
+        pdf_path = get_pdf_path(path)
+
+        _dir = pathlib.Path(f"{output_dir}/{pdf_path}/{name}/")
         _dir.mkdir(parents=True, exist_ok=True)
 
         pdf_src = fitz.open(path)

--- a/remarks/remarks.py
+++ b/remarks/remarks.py
@@ -8,7 +8,13 @@ from .conversion.drawing import draw_svg, draw_pdf
 from .conversion.text import md_from_blocks, is_text_extractable
 from .conversion.ocrmypdf import is_tool, run_ocr
 
-from .utils import get_pdf_name, get_pdf_path, get_pdf_page_dims, list_pages_uuids, list_ann_rm_files
+from .utils import (
+    get_visible_name,
+    get_ui_path,
+    get_pdf_page_dims,
+    list_pages_uuids,
+    list_ann_rm_files,
+)
 
 
 def prepare_subdir(base_dir, fmt):
@@ -22,7 +28,7 @@ def run_remarks(input_dir, output_dir, targets=None, pdf_name=None, ann_type=Non
         w, h = get_pdf_page_dims(path)
 
         pages = list_pages_uuids(path)
-        name = get_pdf_name(path)
+        name = get_visible_name(path)
         rm_files = list_ann_rm_files(path)
 
         if pdf_name and (pdf_name not in name):
@@ -32,16 +38,16 @@ def run_remarks(input_dir, output_dir, targets=None, pdf_name=None, ann_type=Non
             continue
 
         page_magnitude = math.floor(math.log10(len(pages))) + 1
+        in_device_path = get_ui_path(path)
 
-        pdf_path = get_pdf_path(path)
-
-        _dir = pathlib.Path(f"{output_dir}/{pdf_path}/{name}/")
+        _dir = pathlib.Path(f"{output_dir}/{in_device_path}/{name}/")
         _dir.mkdir(parents=True, exist_ok=True)
 
         pdf_src = fitz.open(path)
 
         print(f"Working on PDF file: {path}")
         print(f'PDF visibleName: "{name}"')
+        print(f"PDF in-device directory: {in_device_path}")
 
         for rm_file in rm_files:
             page_idx = pages.index(f"{rm_file.stem}")
@@ -54,9 +60,9 @@ def run_remarks(input_dir, output_dir, targets=None, pdf_name=None, ann_type=Non
             elif ann_type == "scribbles":
                 parsed_data = scribbles
             else:  # get both types
-                parsed_data = {'layers': highlights['layers'] + scribbles['layers']}
+                parsed_data = {"layers": highlights["layers"] + scribbles["layers"]}
 
-            if not parsed_data.get('layers'):
+            if not parsed_data.get("layers"):
                 continue
 
             if "svg" in targets:

--- a/remarks/utils.py
+++ b/remarks/utils.py
@@ -2,6 +2,7 @@ import json
 import pathlib
 
 import fitz  # PyMuPDF
+from os.path import dirname, abspath, join
 
 
 def get_pdf_name(path):
@@ -12,6 +13,30 @@ def get_pdf_name(path):
     # print(metadata)
     return metadata["visibleName"]
 
+def get_pdf_path(path):
+    metadata_file = path.with_name(f"{path.stem}.metadata")
+    if not metadata_file.exists():
+        return None
+    metadata = json.loads(open(metadata_file).read())
+    # Check the parent 
+    path_tmp = ""
+    file_path = path
+    parent_filename = metadata["parent"]
+    while parent_filename != "":
+        # First get the total path of the parent
+        parent_path = join(dirname(abspath(file_path)), metadata["parent"])
+        # Get the meta data of this parent
+        metadata_file = parent_path + ".metadata"
+        metadata = json.loads(open(metadata_file).read())
+        parent_title = metadata["visibleName"]
+        # These go in reverse order up to the top level
+        path_tmp = join(parent_title,path_tmp)
+        # Get the parent of this one
+        parent_filename = metadata["parent"]
+    # Strip off final slash
+    path_tmp = path_tmp.strip("/")
+    path_tmp = path_tmp.strip("\\")
+    return path_tmp
 
 def get_pdf_page_dims(path, page_number=0):
     with fitz.open(path) as doc:

--- a/remarks/utils.py
+++ b/remarks/utils.py
@@ -3,8 +3,6 @@ import pathlib
 
 import fitz  # PyMuPDF
 
-from os.path import dirname, abspath, join
-
 
 def read_meta_file(path, suffix=".metadata"):
     file = path.with_name(f"{path.stem}{suffix}")


### PR DESCRIPTION
This PR superseeds PR #4 Keep Directory structure by [folofjc](https://github.com/folofjc)

Summary of amendments:

- Removed import os.path in favor of pathlib only (see: https://docs.python.org/3/library/pathlib.html#correspondence-to-tools-in-the-os-module)
- Applied black code formatter
- Renamed a few variables
- Extracted a new function