### PR TITLE
The main loop now iterates over metadata files instead of PDF files

### DIFF
--- a/remarks/remarks.py
+++ b/remarks/remarks.py
@@ -16,6 +16,8 @@ from .conversion.text import md_from_blocks, is_text_extractable
 from .conversion.ocrmypdf import is_tool, run_ocr
 
 from .utils import (
+    is_document,
+    get_document_filetype,
     get_visible_name,
     get_ui_path,
     get_pdf_page_dims,
@@ -39,153 +41,160 @@ def run_remarks(
     combined_pdf=False,
     modified_pdf=False,
 ):
-    for path in pathlib.Path(f"{input_dir}/").glob("*.pdf"):
-        pages = list_pages_uuids(path)
-        name = get_visible_name(path)
-        rm_files = list_ann_rm_files(path)
-
-        if pdf_name and (pdf_name not in name):
+    for path in pathlib.Path(f"{input_dir}/").glob("*.metadata"):
+        if not is_document(path):
             continue
 
-        if not pages or not name or not rm_files or not len(rm_files):
-            continue
+        filetype = get_document_filetype(path)
+        if filetype == 'pdf':
+            pages = list_pages_uuids(path)
+            name = get_visible_name(path)
+            rm_files = list_ann_rm_files(path)
 
-        page_magnitude = math.floor(math.log10(len(pages))) + 1
-        in_device_path = get_ui_path(path)
-
-        out_path = pathlib.Path(f"{output_dir}/{in_device_path}/{name}/")
-        out_path.mkdir(parents=True, exist_ok=True)
-
-        pdf_src = fitz.open(path)
-
-        if modified_pdf:
-            mod_pdf = fitz.open()
-
-        print(f"Working on PDF file: {path}")
-        print(f'PDF visibleName: "{name}"')
-        print(f"PDF in-device directory: {in_device_path}")
-
-        for rm_file in rm_files:
-            page_idx = pages.index(f"{rm_file.stem}")
-
-            pdf_w, pdf_h = get_pdf_page_dims(path, page_idx=page_idx)
-            scale = get_pdf_to_device_ratio(pdf_w, pdf_h)
-
-            highlights, scribbles = parse_rm_file(rm_file)
-
-            if ann_type == "highlights":
-                parsed_data = highlights
-            elif ann_type == "scribbles":
-                parsed_data = scribbles
-            else:  # merge both annotation types
-                parsed_data = {"layers": highlights["layers"] + scribbles["layers"]}
-
-            if not parsed_data.get("layers"):
+            if pdf_name and (pdf_name not in name):
                 continue
 
-            parsed_data = rescale_parsed_data(parsed_data, scale)
+            if not pages or not name or not rm_files or not len(rm_files):
+                continue
 
-            if "svg" in targets:
-                svg_str = draw_svg(parsed_data)
+            page_magnitude = math.floor(math.log10(len(pages))) + 1
+            in_device_path = get_ui_path(path)
 
-                subdir = prepare_subdir(out_path, "svg")
-                with open(f"{subdir}/{page_idx:0{page_magnitude}}.svg", "w") as f:
-                    f.write(svg_str)
+            out_path = pathlib.Path(f"{output_dir}/{in_device_path}/{name}/")
+            out_path.mkdir(parents=True, exist_ok=True)
 
-            ann_doc = fitz.open()
-
-            rm_w_rescaled, rm_h_scaled = get_rescaled_device_dims(scale)
-            ann_page = ann_doc.newPage(width=rm_w_rescaled, height=rm_h_scaled)
-
-            pdf_w_adj, pdf_h_adj = get_adjusted_pdf_dims(pdf_w, pdf_h, scale)
-            pdf_rect = fitz.Rect(0, 0, pdf_w_adj, pdf_h_adj)
-
-            ann_page.showPDFpage(pdf_rect, pdf_src, pno=page_idx)
-
-            should_extract_text = ann_type != "scribbles" and highlights
-            extractable = is_text_extractable(pdf_src[page_idx])
-            ocred = False
-
-            if should_extract_text and not extractable and is_tool("ocrmypdf"):
-                print(
-                    f"Couldn't extract text from page #{page_idx}. Will OCR it. Hold on\n"
-                )
-
-                tmp_file = "_tmp.pdf"
-                ann_doc.save(tmp_file)
-                ann_doc.close()
-
-                # Note: as of July 2020, ocrmypdf does not recognize handwriting
-                tmp_file = run_ocr(tmp_file)
-
-                ann_doc = fitz.open(tmp_file)
-                pathlib.Path(tmp_file).unlink()
-
-                ann_page = ann_doc[0]
-                ocred = True
-
-            ann_page = draw_pdf(parsed_data, ann_page)
-
-            if "pdf" in targets:
-                subdir = prepare_subdir(out_path, "pdf")
-                ann_doc.save(f"{subdir}/{page_idx:0{page_magnitude}}.pdf")
-
-            if "png" in targets:
-                # (2, 2) is a short-hand for 2x zoom on x and y
-                # ref: https://pymupdf.readthedocs.io/en/latest/page.html#Page.getPixmap
-                pixmap = ann_page.getPixmap(matrix=fitz.Matrix(2, 2))
-
-                subdir = prepare_subdir(out_path, "png")
-                pixmap.writePNG(f"{subdir}/{page_idx:0{page_magnitude}}.png")
-
-            if "md" in targets:
-                if should_extract_text and (extractable or ocred):
-                    md_str = md_from_blocks(ann_page)
-                    # TODO: add proper table extraction?
-                    # https://pymupdf.readthedocs.io/en/latest/faq.html#how-to-extract-tables-from-documents
-
-                    # TODO: maybe also add highlighted image (pixmap) extraction?
-
-                    subdir = prepare_subdir(out_path, "md")
-                    with open(f"{subdir}/{page_idx:0{page_magnitude}}.md", "w") as f:
-                        f.write(md_str)
-
-                elif not highlights:
-                    print(f"Couldn't find any highlighted text on page #{page_idx}")
-                elif ann_type == "scribbles":
-                    print(
-                        "Found some highlighted text but `--ann_type` flag was set to `scribbles` only"
-                    )
-                else:
-                    print(
-                        f"Found highlighted text but couldn't create markdown from page #{page_idx}"
-                    )
+            pdf_src = fitz.open(path.with_name(f"{path.stem}.pdf"))
 
             if modified_pdf:
-                mod_pdf.insertPDF(ann_doc, start_at=-1)
+                mod_pdf = fitz.open()
+
+            print(f"Working on PDF file: {path.stem}")
+            print(f'PDF visibleName: "{name}"')
+            print(f"PDF in-device directory: {in_device_path}")
+
+            for rm_file in rm_files:
+                page_idx = pages.index(f"{rm_file.stem}")
+
+                pdf_w, pdf_h = get_pdf_page_dims(path, page_idx=page_idx)
+                scale = get_pdf_to_device_ratio(pdf_w, pdf_h)
+
+                highlights, scribbles = parse_rm_file(rm_file)
+
+                if ann_type == "highlights":
+                    parsed_data = highlights
+                elif ann_type == "scribbles":
+                    parsed_data = scribbles
+                else:  # merge both annotation types
+                    parsed_data = {"layers": highlights["layers"] + scribbles["layers"]}
+
+                if not parsed_data.get("layers"):
+                    continue
+
+                parsed_data = rescale_parsed_data(parsed_data, scale)
+
+                if "svg" in targets:
+                    svg_str = draw_svg(parsed_data)
+
+                    subdir = prepare_subdir(out_path, "svg")
+                    with open(f"{subdir}/{page_idx:0{page_magnitude}}.svg", "w") as f:
+                        f.write(svg_str)
+
+                ann_doc = fitz.open()
+
+                rm_w_rescaled, rm_h_scaled = get_rescaled_device_dims(scale)
+                ann_page = ann_doc.newPage(width=rm_w_rescaled, height=rm_h_scaled)
+
+                pdf_w_adj, pdf_h_adj = get_adjusted_pdf_dims(pdf_w, pdf_h, scale)
+                pdf_rect = fitz.Rect(0, 0, pdf_w_adj, pdf_h_adj)
+
+                ann_page.showPDFpage(pdf_rect, pdf_src, pno=page_idx)
+
+                should_extract_text = ann_type != "scribbles" and highlights
+                extractable = is_text_extractable(pdf_src[page_idx])
+                ocred = False
+
+                if should_extract_text and not extractable and is_tool("ocrmypdf"):
+                    print(
+                        f"Couldn't extract text from page #{page_idx}. Will OCR it. Hold on\n"
+                    )
+
+                    tmp_file = "_tmp.pdf"
+                    ann_doc.save(tmp_file)
+                    ann_doc.close()
+
+                    # Note: as of July 2020, ocrmypdf does not recognize handwriting
+                    tmp_file = run_ocr(tmp_file)
+
+                    ann_doc = fitz.open(tmp_file)
+                    pathlib.Path(tmp_file).unlink()
+
+                    ann_page = ann_doc[0]
+                    ocred = True
+
+                ann_page = draw_pdf(parsed_data, ann_page)
+
+                if "pdf" in targets:
+                    subdir = prepare_subdir(out_path, "pdf")
+                    ann_doc.save(f"{subdir}/{page_idx:0{page_magnitude}}.pdf")
+
+                if "png" in targets:
+                    # (2, 2) is a short-hand for 2x zoom on x and y
+                    # ref: https://pymupdf.readthedocs.io/en/latest/page.html#Page.getPixmap
+                    pixmap = ann_page.getPixmap(matrix=fitz.Matrix(2, 2))
+
+                    subdir = prepare_subdir(out_path, "png")
+                    pixmap.writePNG(f"{subdir}/{page_idx:0{page_magnitude}}.png")
+
+                if "md" in targets:
+                    if should_extract_text and (extractable or ocred):
+                        md_str = md_from_blocks(ann_page)
+                        # TODO: add proper table extraction?
+                        # https://pymupdf.readthedocs.io/en/latest/faq.html#how-to-extract-tables-from-documents
+
+                        # TODO: maybe also add highlighted image (pixmap) extraction?
+
+                        subdir = prepare_subdir(out_path, "md")
+                        with open(f"{subdir}/{page_idx:0{page_magnitude}}.md", "w") as f:
+                            f.write(md_str)
+
+                    elif not highlights:
+                        print(f"Couldn't find any highlighted text on page #{page_idx}")
+                    elif ann_type == "scribbles":
+                        print(
+                            "Found some highlighted text but `--ann_type` flag was set to `scribbles` only"
+                        )
+                    else:
+                        print(
+                            f"Found highlighted text but couldn't create markdown from page #{page_idx}"
+                        )
+
+                if modified_pdf:
+                    mod_pdf.insertPDF(ann_doc, start_at=-1)
+
+                if combined_pdf:
+                    x_max, y_max = get_ann_max_bound(parsed_data)
+                    ann_outside = (x_max > pdf_w_adj) or (y_max > pdf_h_adj)
+
+                    # If there are annotations outside the original PDF page limits,
+                    # insert the ann_page that we have created from scratch
+                    if ann_outside:
+                        pdf_src.insertPDF(ann_doc, start_at=page_idx)
+                        pdf_src.deletePage(page_idx + 1)
+
+                    # Else, draw annotations in the original PDF page (in-place)
+                    # to preserve links (and also the original page size)
+                    else:
+                        draw_pdf(parsed_data, pdf_src[page_idx], inplace=True)
+
+                ann_doc.close()
 
             if combined_pdf:
-                x_max, y_max = get_ann_max_bound(parsed_data)
-                ann_outside = (x_max > pdf_w_adj) or (y_max > pdf_h_adj)
+                pdf_src.save(f"{output_dir}/{name} _remarks.pdf")
 
-                # If there are annotations outside the original PDF page limits,
-                # insert the ann_page that we have created from scratch
-                if ann_outside:
-                    pdf_src.insertPDF(ann_doc, start_at=page_idx)
-                    pdf_src.deletePage(page_idx + 1)
+            if modified_pdf:
+                mod_pdf.save(f"{output_dir}/{name} _remarks-only.pdf")
+                mod_pdf.close()
 
-                # Else, draw annotations in the original PDF page (in-place)
-                # to preserve links (and also the original page size)
-                else:
-                    draw_pdf(parsed_data, pdf_src[page_idx], inplace=True)
-
-            ann_doc.close()
-
-        if combined_pdf:
-            pdf_src.save(f"{output_dir}/{name} _remarks.pdf")
-
-        if modified_pdf:
-            mod_pdf.save(f"{output_dir}/{name} _remarks-only.pdf")
-            mod_pdf.close()
-
-        pdf_src.close()
+            pdf_src.close()
+        else:
+            print(f"Skipping document {path.stem}: document type: {filetype} is currently not supported.")

--- a/remarks/utils.py
+++ b/remarks/utils.py
@@ -12,6 +12,16 @@ def read_meta_file(path, suffix=".metadata"):
     return data
 
 
+def is_document(path):
+    metadata = read_meta_file(path)
+    return metadata["type"] == 'DocumentType'
+
+
+def get_document_filetype(path):
+    content = read_meta_file(path, suffix=".content")
+    return content["fileType"]
+
+
 def get_visible_name(path):
     metadata = read_meta_file(path)
     return metadata["visibleName"]
@@ -45,7 +55,7 @@ def get_ui_path(path):
 
 
 def get_pdf_page_dims(path, page_idx=0):
-    with fitz.open(path) as doc:
+    with fitz.open(path.with_name(f"{path.stem}.pdf")) as doc:
         first_page = doc.loadPage(page_idx)
         return first_page.rect.width, first_page.rect.height
 


### PR DESCRIPTION
The main loop now iterates over metadata files instead of PDF files, then checks whether the current item is a document, and whether its document type is supported. This allows to indicate in the console that non-PDF documents (such as notebooks) will not be converted as they are currently unsupported.

This is groundwork in the context of Issue #11. Feel free to not merge if you deem this single change too slight, however review and comment would be very appreciated before taking on further, bigger code changes. Python is not my daily language so by all means change things if you see something non-optimal.

For the record this small change does solve an issue I encountered myself: when first testing the codebase on a copy of my own xochitl directory there were notebooks documents inside the directory but not a single annotated PDF. I did not realized remarks did not support notebooks, so I launched the code anyways and nothing at all was printed on the console. So for a few seconds I did not know whether everything had gone smoothly or if nothing had happened at all. This change makes this clearer.