### PR TITLE
Added option to use PDF text order instead of sorting

### DIFF
--- a/remarks/__main__.py
+++ b/remarks/__main__.py
@@ -4,7 +4,7 @@ import argparse
 from remarks import run_remarks
 
 __prog_name__ = "remarks"
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 
 
 def main():
@@ -48,7 +48,14 @@ def main():
         dest="modified_pdf",
         action="store_true",
         help="Create a '*_remarks-only.pdf' file with all annotated pages",
-    )    
+    )
+    parser.add_argument(
+        "-f",
+        "--assume_wellformed",
+        dest="assume_wellformed",
+        action="store_true",
+        help="Assumes a well-formed PDF where words are in order."
+    )
     parser.add_argument(
         "-v",
         "--version",
@@ -60,7 +67,8 @@ def main():
         "-h", "--help", action="help", help="Show this help message",
     )
 
-    parser.set_defaults(combined_pdf=False, modified_pdf=False)
+    parser.set_defaults(combined_pdf=False, modified_pdf=False,
+                        assume_wellformed=False)
 
     args = parser.parse_args()
     args_dict = vars(args)

--- a/remarks/conversion/__init__.py
+++ b/remarks/conversion/__init__.py
@@ -9,6 +9,6 @@ from .parsing import (
 
 from .drawing import draw_svg, draw_pdf
 
-from .text import md_from_blocks, is_text_extractable
+from .text import md_from_blocks, is_text_extractable, extract_highlighted_words_nosort
 
 from .ocrmypdf import is_tool, run_ocr

--- a/remarks/conversion/text.py
+++ b/remarks/conversion/text.py
@@ -14,12 +14,13 @@ def get_highlight_rects(page):
     return highlight_rects
 
 
-def get_page_words(page, flags=(1 + 2 + 8)):
+def get_page_words(page, flags=(1 + 2 + 8), sort=True):
     # https://pymupdf.readthedocs.io/en/latest/app2.html#text-extraction-flags-defaults
     # https://github.com/pymupdf/PyMuPDF/issues/363
     words = page.getText("words", flags=flags)
 
-    words.sort(key=lambda w: (w[3], w[0]))  # ascending y, then x coordinate
+    if sort:
+        words.sort(key=lambda w: (w[3], w[0]))  # ascending y, then x coordinate
     # print(words)
 
     return words
@@ -71,7 +72,7 @@ def extract_highlighted_words_nosort(page):
     Modified version of extract_highlighted_words, but without sorting text by
     physical coordinates.
     '''
-    words = get_page_words(page, flags=(2))
+    words = get_page_words(page, flags=(2), sort=False)
     highlight_rects = get_highlight_rects(page)
 
     # Create a boolean mask for each extracted word, depending on whether it

--- a/remarks/remarks.py
+++ b/remarks/remarks.py
@@ -13,6 +13,7 @@ from .conversion.parsing import (
 )
 from .conversion.drawing import draw_svg, draw_pdf
 from .conversion.text import md_from_blocks, is_text_extractable
+from .conversion.text import extract_highlighted_words_nosort
 from .conversion.ocrmypdf import is_tool, run_ocr
 
 from .utils import (
@@ -40,6 +41,7 @@ def run_remarks(
     ann_type=None,
     combined_pdf=False,
     modified_pdf=False,
+    assume_wellformed=False
 ):
     for path in pathlib.Path(f"{input_dir}/").glob("*.metadata"):
         if not is_document(path):
@@ -73,7 +75,10 @@ def run_remarks(
             print(f"PDF in-device directory: {in_device_path}")
 
             for rm_file in rm_files:
-                page_idx = pages.index(f"{rm_file.stem}")
+                try:
+                    page_idx = pages.index(f"{rm_file.stem}")
+                except:
+                    page_idx = int(f"{rm_file.stem}")
 
                 pdf_w, pdf_h = get_pdf_page_dims(path, page_idx=page_idx)
                 scale = get_pdf_to_device_ratio(pdf_w, pdf_h)
@@ -147,7 +152,10 @@ def run_remarks(
 
                 if "md" in targets:
                     if should_extract_text and (extractable or ocred):
-                        md_str = md_from_blocks(ann_page)
+                        if assume_wellformed:
+                            md_str = extract_highlighted_words_nosort(ann_page)
+                        else:
+                            md_str = md_from_blocks(ann_page)
                         # TODO: add proper table extraction?
                         # https://pymupdf.readthedocs.io/en/latest/faq.html#how-to-extract-tables-from-documents
 


### PR DESCRIPTION
I took an attempt at addressing issue #18, adding in a new flag to force the use of PDF word ordering instead of sorting by page coordinates.

Some other modifications:
- When using [rmapi](https://github.com/juruen/rmapi) to sync files, the page index generated is an integer instead of a string.
- Checking for obfuscated fonts with the string "\xef\xbf\xbd" trips up PDF files with math and equations, so I've commented it out. I'm not sure of a better check.