### PR TITLE
Add debug logging

### DIFF
--- a/remarks/__main__.py
+++ b/remarks/__main__.py
@@ -1,3 +1,4 @@
+import logging
 import pathlib
 import argparse
 
@@ -69,17 +70,31 @@ def main():
         help="Show version number",
         version="%(prog)s {version}".format(version=__version__),
     )
+
+    parser.add_argument(
+        "-d",
+        "--debug",
+        actions="store_true",
+        help="Print debug statements"
+    )
+
     parser.add_argument(
         "-h", "--help", action="help", help="Show this help message",
     )
 
-    parser.set_defaults(combined_pdf=False, modified_pdf=False, assume_wellformed=False, combined_md=False)
+    parser.set_defaults(combined_pdf=False, modified_pdf=False, assume_wellformed=False, combined_md=False, debug=False)
 
     args = parser.parse_args()
     args_dict = vars(args)
 
     input_dir = args_dict.pop("input_dir")
     output_dir = args_dict.pop("output_dir")
+
+    debug = args_dict.pop("debug")
+
+    logging.basicConfig(format='%(asctime)s %(name)-12s %(levelname)-8s %(message)s',
+                                 level=logging.DEBUG if debug else logging.WARNING)
+
 
     if not pathlib.Path(input_dir).exists():
         parser.error(f'Directory "{input_dir}" does not exist.')

--- a/remarks/conversion/ocrmypdf.py
+++ b/remarks/conversion/ocrmypdf.py
@@ -1,3 +1,4 @@
+import logging
 import subprocess
 
 import fitz
@@ -35,7 +36,7 @@ def run_ocr(tmp_file, languages="eng"):
 
     # print(cmd_args)
 
-    p = subprocess.run(cmd_args)
-    print(f"{p}\n")
+    p = subprocess.run(cmd_args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+    logging.debug(f"{p.stdout}\n")
 
     return tmp_file

--- a/remarks/remarks.py
+++ b/remarks/remarks.py
@@ -1,3 +1,4 @@
+import logging
 import math
 import pathlib
 
@@ -75,9 +76,9 @@ def run_remarks(
                 mod_pdf = fitz.open()
                 pages_order = []
 
-            print(f"Working on PDF file: {path.stem}")
-            print(f'PDF visibleName: "{name}"')
-            print(f"PDF in-device directory: {in_device_path}")
+            logging.info(f"Working on PDF file: {path.stem}")
+            logging.info(f'PDF visibleName: "{name}"')
+            logging.info(f"PDF in-device directory: {in_device_path}")
 
             for rm_file in rm_files:
                 try:
@@ -126,7 +127,7 @@ def run_remarks(
                 ocred = False
 
                 if should_extract_text and not extractable and is_tool("ocrmypdf"):
-                    print(
+                    logging.warning(
                         f"- Couldn't extract text from page #{page_idx}. Will OCR it. Hold on\n"
                     )
 
@@ -176,18 +177,17 @@ def run_remarks(
                             subdir = prepare_subdir(out_path, "md")
                             with open(f"{subdir}/{page_idx:0{page_magnitude}}.md", "w") as f:
                                 f.write(md_str)
-                    
-                    else:
-                        print(
-                            f"- Found highlighted text but couldn't extract markdown from highlights on page #{page_idx}"
-                        )                        
 
-                # TODO: add a proper verbose mode (which is off by default)
+                    else:
+                        logging.warning(
+                            f"- Found highlighted text but couldn't extract markdown from highlights on page #{page_idx}"
+                        )
+
                 elif not len(highlights["layers"]) > 0:
-                    print(f"- Couldn't find any highlighted text on page #{page_idx}")
+                    logging.warning(f"- Couldn't find any highlighted text on page #{page_idx}")
 
                 elif len(highlights["layers"]) > 0 and ann_type == "scribbles":
-                    print(
+                    logging.warning(
                         "- Found some highlighted text but `--ann_type` flag was set to `scribbles` only"
                     )
 
@@ -231,4 +231,4 @@ def run_remarks(
 
             pdf_src.close()
         else:
-            print(f"Skipped {filetype} file {path.stem}. Currently, remarks supports only PDF")
+            logging.warning(f"Skipped {filetype} file {path.stem}. Currently, remarks supports only PDF")


### PR DESCRIPTION
Add debug logging.

When `-d/--debug` is set, logging is set to log debug messages, otherwise it logs warn level messages.

@lucasrla for review: I picked the logging levels to what seemed appropriate, but please do change it as appropriate.