### PR TITLE
Add a flag to enable ocr my pdf

### DIFF
--- a/remarks/__main__.py
+++ b/remarks/__main__.py
@@ -70,10 +70,16 @@ def main():
         version="%(prog)s {version}".format(version=__version__),
     )
     parser.add_argument(
+        "-ocr",
+        "--use-ocr",
+        action="store_true",
+        help="Use OCRmyPDF, ocrmypdf executable must be accessible on the PATH."
+    )
+    parser.add_argument(
         "-h", "--help", action="help", help="Show this help message",
     )
 
-    parser.set_defaults(combined_pdf=False, modified_pdf=False, assume_wellformed=False, combined_md=False)
+    parser.set_defaults(combined_pdf=False, modified_pdf=False, assume_wellformed=False, combined_md=False, use_ocr=False)
 
     args = parser.parse_args()
     args_dict = vars(args)
@@ -86,6 +92,10 @@ def main():
 
     if not pathlib.Path(output_dir).is_dir():
         pathlib.Path(output_dir).mkdir(parents=True, exist_ok=True)
+
+    if not is_tool("ocrmypdf") and args_dict.use_ocr:
+        print("Cannot find ocrmypdf in path but --use-ocr option was set to True. Please install ocrmypdf for your system.")
+        sys.exit(1)
 
     run_remarks(input_dir, output_dir, **args_dict)
 

--- a/remarks/remarks.py
+++ b/remarks/remarks.py
@@ -42,7 +42,8 @@ def run_remarks(
     combined_pdf=False,
     modified_pdf=False,
     assume_wellformed=False,
-    combined_md=False
+    combined_md=False,
+    use_ocr=False
 ):
     for path in pathlib.Path(f"{input_dir}/").glob("*.metadata"):
         if not is_document(path):
@@ -125,7 +126,7 @@ def run_remarks(
 
                 ocred = False
 
-                if should_extract_text and not extractable and is_tool("ocrmypdf"):
+                if should_extract_text and not extractable and use_ocr:
                     print(
                         f"- Couldn't extract text from page #{page_idx}. Will OCR it. Hold on\n"
                     )


### PR DESCRIPTION
Using `ocrmypdf` by default if it is found usually makes sense, however if trying to run remarks on a large collection of pdfs, it can take quite a while....

This PR adds the ability for the user to specific if they want to use the OCR functionality. It is set to false by default for quicker runs. 

Turned on with `--use-ocr/-ocr`

An error is also thrown if the flag is set but the tool is not found.

@lucasrla for review

---

As an aside, I've tried to make this a bit faster by parallelizing calls to ocrmypdf but I ended up running into some segfaults. I'll revisit that at some point, but in case, the sane default should be set to false to encourage quicker runs (at the expense of some accuracy)...