### PR TITLE
Add support for highlighter colours in 2.13

### DIFF
--- a/remarks/conversion/drawing.py
+++ b/remarks/conversion/drawing.py
@@ -4,7 +4,7 @@ import fitz  # PyMuPDF
 import shapely.geometry as geom  # Shapely
 
 GRAYSCALE = {0: "black", 1: "grey", 2: "white"}
-COLOR = {0: "blue", 1: "red", 2: "white", 3: "yellow"}
+COLOR = {0: "black", 1: "red", 2: "white", 3: "yellow", 4: "green", 5: "magenta", 6: "blue", 8: "gray"}
 
 
 def draw_svg(data, dims={"x": RM_WIDTH, "y": RM_HEIGHT}, color=True):
@@ -111,6 +111,10 @@ def draw_pdf(data, page, color=True, inplace=False):
                 # TODO: setOpacity and setBorder not working with HighlightAnnot
                 # maybe related to https://github.com/pymupdf/PyMuPDF/issues/421
                 # see also: https://pymupdf.readthedocs.io/en/latest/faq.html#how-to-add-and-modify-annotations
+
+                # now supporting colors
+                color_array = fitz.utils.getColor(c[seg_data["color-code"]])
+                annot.setColors(stroke=color_array)
 
                 annot.setOpacity(seg_data["opacity"])
                 annot.setBorder(width=seg_data["stroke-width"])

--- a/remarks/conversion/parsing.py
+++ b/remarks/conversion/parsing.py
@@ -86,7 +86,6 @@ def process_tool_meta(pen, dims, w, opc, cc):
     elif tool == "Highlighter":
         w = 30
         opc = 0.6
-        cc = 3
     elif tool == "Eraser":
         w = 1280 * w * w - 4800 * w + 4510
         cc = 2
@@ -257,7 +256,7 @@ def parse_rm_file(file_path, highlight_file_path, dims={"x": RM_WIDTH, "y": RM_H
             # First, see if the highlighter18 is added
             w = 0
             opc = 0
-            cc = 0
+            cc = hl["color"]
             tool, tool_meta, stroke_width, opacity = process_tool_meta(
                 18, dims, w, opc, cc
             )
@@ -270,6 +269,7 @@ def parse_rm_file(file_path, highlight_file_path, dims={"x": RM_WIDTH, "y": RM_H
             # Need to loop through them. But a segment is a rect
             seg_name = "new"+ str(temp_cnt)
             stroke_width = hl["rects"][0]["height"]
+            tool = "{}_{}".format(tool, cc) # quick hack: treat marker colors as different tools
 
             if tool not in l["strokes"].keys():
                 l["strokes"] = update_stroke_dict(l["strokes"], tool, tool_meta)


### PR DESCRIPTION
Hi, this continues the work by @folofjc in #38 on supporting the new highlighter format. I added support for the new highlighter colours (yellow, green, pink, grey). This should fix #39.

I tried to change as little as possible, so it might not be the most elegant solution but it works :) My remarkable is on 2.13 and so far I did not encounter any errors.