### PR TITLE
Minor fbug ixes with detailed comits

### DIFF
--- a/remarks/remarks.py
+++ b/remarks/remarks.py
@@ -78,7 +78,6 @@ def run_remarks(input_dir, output_dir, file_name=None, **kwargs):
 
             in_device_dir = get_ui_path(metadata_path)
             out_path = pathlib.Path(f"{output_dir}/{in_device_dir}/{doc_name}/")
-            out_path.mkdir(parents=True, exist_ok=True)
             # print("out_path:", out_path)
 
             process_document(metadata_path, out_path, doc_type, **kwargs)
@@ -342,6 +341,7 @@ def process_document(
             )
 
         if per_page_targets:
+            out_path.mkdir(parents=True, exist_ok=True)
             if "pdf" in per_page_targets:
                 subdir = prepare_subdir(out_path, "pdf")
                 work_doc.save(f"{subdir}/{page_idx:0{pages_magnitude}}.pdf")

--- a/remarks/remarks.py
+++ b/remarks/remarks.py
@@ -403,7 +403,7 @@ def process_document(
 
         work_doc.close()
 
-    out_doc_path_str = f"{out_path.parent}/{out_path.stem}"
+    out_doc_path_str = f"{out_path.parent}/{out_path.name}"
     # print("out_doc_path_str:", out_doc_path_str)
 
     if combined_pdf:
@@ -430,13 +430,13 @@ def process_document(
             combined_md_str = "".join(
                 [f"\n## Page {s[0]}\n\n" + s[1] for s in combined_md_strs]
             )
-            combined_md_str = f"# {out_path.stem}\n" + combined_md_str
+            combined_md_str = f"# {out_path.name}\n" + combined_md_str
 
         elif md_header_format == "setex":
             combined_md_str = "".join(
                 [f"\nPage {s[0]}\n--------\n" + s[1] for s in combined_md_strs]
             )
-            combined_md_str = f"{out_path.stem}\n========\n" + combined_md_str
+            combined_md_str = f"{out_path.name}\n========\n" + combined_md_str
 
         with open(f"{out_doc_path_str} _highlights.md", "w") as f:
             f.write(combined_md_str)

--- a/remarks/utils.py
+++ b/remarks/utils.py
@@ -68,7 +68,7 @@ def list_ann_rm_files(path):
     content_dir = pathlib.Path(f"{path.parents[0]}/{path.stem}/")
     # print("content_dir", content_dir, not content_dir.is_dir())
     if not content_dir.is_dir():
-        return None
+        return []
     return list(content_dir.glob("*.rm"))
 
 


### PR DESCRIPTION
I started using this super useful tool for my use case and had to iron out a few things to make things work. Here are three very minor bug fixing changes with detailed commits, in summary:

* No annotations returned `None`, then the test `len(ann_rm_files) == 0" would error. Changed `None` to `[]`, mimics the `hl_json_files`highlight equivalent
* A folder was created to store the `per_page_targets`, even if no per_page_target was provided. Moved the folder creation inside the `if per_page_targets:` block
* In `remarks.py`, `doc_name` contains no file extention, therefore `.stem` is either useless or mangles filenames with dots in them, e.g. a pdf called `author.title.pdf` has `doc_name`=`author.title`, which `.stem` turns into `author`, and is then written out to `author _remarks.pdf`. I replaced `.stem` with `.name` where appropriate.