### PR TITLE
Allows filtering on folder, or metadata's uuid

### DIFF
--- a/remarks/__main__.py
+++ b/remarks/__main__.py
@@ -27,6 +27,16 @@ def main():
         metavar="FILENAME_STRING",
     )
     parser.add_argument(
+        "--file_uuid",
+        help="Work only on files whose uuid is this string",
+        metavar="UUID_STRING",
+    )
+    parser.add_argument(
+        "--file_path",
+        help="Work only on files whose (meaningful) path contains this string",
+        metavar="UUID_STRING",
+    )
+    parser.add_argument(
         "--ann_type",
         help="Force remarks to handle only a specific type of annotation: highlights or scribbles. If none is specified, remarks will handle both by default",
         default=["scribbles", "highlights"],

--- a/remarks/remarks.py
+++ b/remarks/remarks.py
@@ -47,7 +47,7 @@ from .utils import (
 # - https://github.com/lucasrla/remarks/issues/11
 
 
-def run_remarks(input_dir, output_dir, file_name=None, **kwargs):
+def run_remarks(input_dir, output_dir, file_name=None, file_uuid=None, file_path=None, **kwargs):
     num_docs = sum(1 for _ in pathlib.Path(f"{input_dir}/").glob("*.metadata"))
 
     if num_docs == 0:
@@ -61,6 +61,9 @@ def run_remarks(input_dir, output_dir, file_name=None, **kwargs):
     )
 
     for metadata_path in pathlib.Path(f"{input_dir}/").glob("*.metadata"):
+        if metadata_path.stem != file_uuid:
+            continue
+
         if not is_document(metadata_path):
             continue
 
@@ -80,6 +83,9 @@ def run_remarks(input_dir, output_dir, file_name=None, **kwargs):
             out_path = pathlib.Path(f"{output_dir}/{in_device_dir}/{doc_name}/")
             out_path.mkdir(parents=True, exist_ok=True)
             # print("out_path:", out_path)
+
+            if file_path is not None and file_path not in str(in_device_dir):
+                continue
 
             process_document(metadata_path, out_path, doc_type, **kwargs)
         else:


### PR DESCRIPTION
It can be convenient to filter the files to process on additional properties, such as (i) the "uuid" filename in the "raw" document files, or (ii) whether the file's meaningful path is inside a specific folders. I added both cases (I need both for my sync setup) with new args.

Again, thanks for sharing your tool!