### PR TITLE
Improve eraser handling

### DIFF
--- a/remarks/conversion/drawing.py
+++ b/remarks/conversion/drawing.py
@@ -8,7 +8,6 @@ from ..utils import (
     RM_HEIGHT,
 )
 
-
 HL_COLOR_CODES = {
     3: "yellow",
     4: "green",
@@ -25,7 +24,9 @@ SC_COLOR_CODES = {
 }
 
 
-def draw_svg(data, dims={"x": RM_WIDTH, "y": RM_HEIGHT}):
+def draw_svg(data, dims={
+    "x": RM_WIDTH,
+    "y": RM_HEIGHT}):
     stroke_color = SC_COLOR_CODES
 
     output = f'<svg xmlns="http://www.w3.org/2000/svg" width="{dims["x"]}" height="{dims["y"]}">'
@@ -164,6 +165,9 @@ def draw_annotations_on_pdf(data, page, inplace=False):
 
         # Scribbles
         else:
+            if seg_data == "Eraser":
+                # Overwrite eraser color to always be white.
+                seg_data['color-code'] = 2
             for seg_points in seg_data["points"]:
                 # https://pymupdf.readthedocs.io/en/latest/recipes-annotations.html#how-to-use-ink-annotations
                 annot = page.add_ink_annot([seg_points])

--- a/remarks/conversion/drawing.py
+++ b/remarks/conversion/drawing.py
@@ -8,6 +8,7 @@ from ..utils import (
     RM_HEIGHT,
 )
 
+
 HL_COLOR_CODES = {
     3: "yellow",
     4: "green",
@@ -24,9 +25,7 @@ SC_COLOR_CODES = {
 }
 
 
-def draw_svg(data, dims={
-    "x": RM_WIDTH,
-    "y": RM_HEIGHT}):
+def draw_svg(data, dims={"x": RM_WIDTH, "y": RM_HEIGHT}):
     stroke_color = SC_COLOR_CODES
 
     output = f'<svg xmlns="http://www.w3.org/2000/svg" width="{dims["x"]}" height="{dims["y"]}">'

--- a/remarks/conversion/parsing.py
+++ b/remarks/conversion/parsing.py
@@ -57,7 +57,7 @@ def process_tool(pen, dims, w, opc):
         opc = 0.6
         # cc = 3
     elif tool == "Eraser":
-        w = 1280 * w * w - 4800 * w + 4510
+        w = w * 6 * 2.3
         # cc = 2
     elif tool == "SharpPencil" or tool == "TiltPencil":
         w = 16 * w - 27


### PR DESCRIPTION
I made two improvements to the eraser.

1. I made sure that the eraser will always draw with a white color.
2. The eraser width now scales linearly with base_width rather than exponentially

I think the fix to always draw with a white color is correct.

The width scaling is still a bit off, but I think it's better to have a more constant scaling.

I have tested this with three notebooks, one is a notebook with hundreds of pages of written text, and the others are shown in the related issue request: https://github.com/lucasrla/remarks/issues/65